### PR TITLE
Move typescript as a devDependencies

### DIFF
--- a/plugins/carbon-ads/package.json
+++ b/plugins/carbon-ads/package.json
@@ -36,7 +36,7 @@
   "peerDependencies": {
     "typedoc": "^0.25.4"
   },
-  "dependencies": {
+  "devDependencies": {
     "typescript": "^5.3.2"
   }
 }

--- a/plugins/clarity/package.json
+++ b/plugins/clarity/package.json
@@ -36,7 +36,7 @@
   "peerDependencies": {
     "typedoc": "^0.25.4"
   },
-  "dependencies": {
+  "devDependencies": {
     "typescript": "^5.3.2"
   }
 }

--- a/plugins/google-ads/package.json
+++ b/plugins/google-ads/package.json
@@ -36,7 +36,7 @@
   "peerDependencies": {
     "typedoc": "^0.25.4"
   },
-  "dependencies": {
+  "devDependencies": {
     "typescript": "^5.3.2"
   }
 }

--- a/plugins/keywords/package.json
+++ b/plugins/keywords/package.json
@@ -36,7 +36,7 @@
   "peerDependencies": {
     "typedoc": "^0.25.4"
   },
-  "dependencies": {
+  "devDependencies": {
     "typescript": "^5.3.2"
   }
 }

--- a/plugins/particles/package.json
+++ b/plugins/particles/package.json
@@ -36,7 +36,7 @@
   "peerDependencies": {
     "typedoc": "^0.25.4"
   },
-  "dependencies": {
+  "devDependencies": {
     "typescript": "^5.3.2"
   }
 }


### PR DESCRIPTION
TypeScript is not needed at runtime. It is only required at dev time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Moved TypeScript dependency to development dependencies across multiple plugins to optimize package installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->